### PR TITLE
Publish under dangerusslee scope

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org/"
-          scope: "@yoda.digital"
+          scope: "@dangerusslee"
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@yoda.digital/gitlab-mcp-server">
-    <img alt="npm" src="https://img.shields.io/npm/v/@yoda.digital/gitlab-mcp-server?color=blue">
+  <a href="https://www.npmjs.com/package/@dangerusslee/gitlab-mcp-server">
+    <img alt="npm" src="https://img.shields.io/npm/v/@dangerusslee/gitlab-mcp-server?color=blue">
   </a>
   <a href="https://github.com/yoda-digital/mcp-gitlab-server/blob/main/LICENSE">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg">
@@ -50,7 +50,7 @@
 #### From npm (Recommended)
 
 ```bash
-npm install @yoda.digital/gitlab-mcp-server
+npm install @dangerusslee/gitlab-mcp-server
 ```
 
 #### From Source
@@ -110,7 +110,7 @@ Add the GitLab MCP server to your MCP settings file:
   "mcpServers": {
     "gitlab": {
       "command": "npx",
-      "args": ["-y", "@yoda.digital/gitlab-mcp-server"],
+      "args": ["-y", "@dangerusslee/gitlab-mcp-server"],
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "your_token_here",
         "GITLAB_API_URL": "https://gitlab.com/api/v4"
@@ -129,7 +129,7 @@ For read-only mode, add the `GITLAB_READ_ONLY_MODE` environment variable:
   "mcpServers": {
     "gitlab-readonly": {
       "command": "npx",
-      "args": ["-y", "@yoda.digital/gitlab-mcp-server"],
+      "args": ["-y", "@dangerusslee/gitlab-mcp-server"],
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "your_token_here",
         "GITLAB_API_URL": "https://gitlab.com/api/v4",
@@ -171,7 +171,7 @@ npm start
 
 ```bash
 # Run directly with npx
-GITLAB_PERSONAL_ACCESS_TOKEN=your_token_here npx @yoda.digital/gitlab-mcp-server
+GITLAB_PERSONAL_ACCESS_TOKEN=your_token_here npx @dangerusslee/gitlab-mcp-server
 ```
 
 ## 🛠️ Available Tools
@@ -879,4 +879,4 @@ Special thanks to:
 ## 📦 NPM Package
 
 This package is available on npm:  
-[https://www.npmjs.com/package/@yoda.digital/gitlab-mcp-server](https://www.npmjs.com/package/@yoda.digital/gitlab-mcp-server)
+[https://www.npmjs.com/package/@dangerusslee/gitlab-mcp-server](https://www.npmjs.com/package/@dangerusslee/gitlab-mcp-server)

--- a/ai_code_of_conduct.md
+++ b/ai_code_of_conduct.md
@@ -72,7 +72,7 @@ Each rule follows this structure:
 - Changes are successfully pushed to the main branch
 - GitHub Actions workflow completes successfully (check Actions tab in repository)
 - Package is successfully published to npm registry (verify in npm registry)
-- Package can be installed with `npm install @yoda.digital/gitlab-mcp-server@[new-version]`
+- Package can be installed with `npm install @dangerusslee/gitlab-mcp-server@[new-version]`
 
 #### RULE_EXCEPTIONS:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@yoda.digital/gitlab-mcp-server",
+  "name": "@dangerusslee/gitlab-mcp-server",
   "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@yoda.digital/gitlab-mcp-server",
+      "name": "@dangerusslee/gitlab-mcp-server",
       "version": "0.2.10",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yoda.digital/gitlab-mcp-server",
+  "name": "@dangerusslee/gitlab-mcp-server",
   "version": "0.2.10",
   "description": "GitLab MCP Server - A Model Context Protocol server for GitLab integration",
   "main": "dist/index.js",
@@ -53,5 +53,8 @@
   "bugs": {
     "url": "https://github.com/yoda-digital/mcp-gitlab-server/issues"
   },
-  "homepage": "https://github.com/yoda-digital/mcp-gitlab-server#readme"
+  "homepage": "https://github.com/yoda-digital/mcp-gitlab-server#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const serverCapabilities: ServerCapabilities = {
 
 // Create server
 const server = new Server({
-  name: "gitlab-mcp-server",
+  name: "@dangerusslee/gitlab-mcp-server",
   version: packageJson.version,
 }, {
   capabilities: serverCapabilities


### PR DESCRIPTION
## Summary
- publish to npm under the `@dangerusslee` scope
- update docs and code of conduct with the new package name
- use the scoped name in server configuration

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7386c4548325bc63929a0a07d362